### PR TITLE
Set aws cli default output to json overriding user profile default

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -85,6 +85,7 @@ if [ ! "$(docker ps -q -f name=${CONTAINER_NAME})" ]; then
       -e ANSIBLE_SSH_RETRIES=10 \
       -e ANSIBLE_COLLECTIONS_PATH="${ANSIBLE_COLLECTIONS_PATH}" \
       -e ANSIBLE_ROLES_PATH="/opt/cldr-runner/roles" \
+      -e AWS_DEFAULT_OUTPUT="json" \
       --mount "type=bind,source=${HOME}/.aws,target=/home/runner/.aws" \
       --mount "type=bind,source=${HOME}/.config,target=/home/runner/.config" \
       --mount "type=bind,source=${HOME}/.ssh,target=/home/runner/.ssh" \


### PR DESCRIPTION
Set aws cli default output to json overriding user profile default, allows Ansible to expect aws cli output in json format for parsing
Fixes #7 