### PR TITLE
run cloudera-manager server config Play on the CM host (fixes Tower not having access to CM port)

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -442,7 +442,7 @@
     - full_cluster
 
 - name: Deploy Cloudera Management Service
-  hosts: localhost
+  hosts: cloudera_manager
   gather_facts: no
   roles:
     - cloudera.cluster.deployment.services.mgmt

--- a/cluster.yml
+++ b/cluster.yml
@@ -342,7 +342,7 @@
     - full_cluster
 
 - name: Configure Cloudera Manager server
-  hosts: localhost
+  hosts: cloudera_manager
   gather_facts: no
   roles:
     - cloudera.cluster.cloudera_manager.config


### PR DESCRIPTION

1 of the many fixes we required  to get the cloudera.cluster (CDP "private cloud") deployment working, run from an Ansible Tower host w/out open ports to the cluster nodes (except for SSH of course).

I wonder what was the reason to have this run on "localhost" in the 1. place ? 
Alternatively, a more "generic" solution could be using following idiom  used in some places:
```
hosts: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
```
And if that PLAY really needs to differentiate to run some tasks on localhost .. maybe better change those tasks to use delegate_to: localhost ?


**More infos:**
The 1. task which failed for us , ran from Tower was: roles/cloudera_manager/admin_password/check/tasks/main.yml
- name: Check the default Cloudera Manager admin password
At first I was wondering, why that task did not also use following `delegate_to` (as the prev. task in that file):
```
> delegate_to: "{{ groups.cloudera_manager[0] if 'cloudera_manager' in groups else 'localhost' }}"
```
(and after fixing that task  like this, we encountered more cm_api calls in that PLAY, that's why I tried to run the whole PLAY on the CM host, and it worked nicely!)
