### PR TITLE
Use raw github content for ansible galaxy requirements

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -302,7 +302,7 @@ Cloudera Deploy does have a single dependency for its own execution, the https:/
 [source, bash]
 ----
 # Get the cldr-runner dependency file first
-curl https://github.com/cloudera-labs/cldr-runner/tree/main/payload/deps/ansible.yml \
+curl https://raw.githubusercontent.com/cloudera-labs/cldr-runner/main/payload/deps/ansible.yml \
     --output requirements.yml
 
 # Install the collections (and their dependencies)


### PR DESCRIPTION
The current URL specified links to the file as viewed in the GitHub UI, calling `curl` on that will download HTML code, not a formatted YAML file.

Using the current value actually hits a 302 redirect:

```
$ curl https://github.com/cloudera-labs/cldr-runner/tree/main/payload/deps/ansible.yml     --output out.txt
$ cat out.txt 
<html><body>You are being <a href="https://github.com/cloudera-labs/cldr-runner/blob/main/payload/deps/ansible.yml">redirected</a>.</body></html>
```

Using the redirect value results in HTML:

```
$ curl https://github.com/cloudera-labs/cldr-runner/blob/main/payload/deps/ansible.yml     --output out.txt
$ head -20 out.txt 

<!DOCTYPE html>
<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
  <head>
    <meta charset="utf-8">
  <link rel="dns-prefetch" href="https://github.githubassets.com">
  <link rel="dns-prefetch" href="https://avatars.githubusercontent.com">
  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">

  <link crossorigin="anonymous" media="all" integrity="sha512-J/5cWm5rrVuxkSgldaK1emf5j30Bs5mRgu0uhuHrG+iwf9mD2LOrkQ32SyN5PADLWzkSDxLS3bW/ScsiM44wzw==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-27fe5c5a6e6bad5bb191282575a2b57a.css" />
# <snipped>
```  

Using the `raw.githubusercontent.com` domain ...

```bash
$ curl https://raw.githubusercontent.com/cloudera-labs/cldr-runner/main/payload/deps/ansible.yml --output requirements.yml
$ cat requirements.yml 
---
# Append other Ansible Collections to this list, e.g.
#  - name: https://github.com/myuser/myrepo.git
#    type: git
#    version: mybranch

collections:

  # Cloudera collections
  - name: https://github.com/cloudera-labs/cloudera.cluster.git
    type: git
# <snipped>
```