### PR TITLE
Update to parcels url and cm version

### DIFF
--- a/roles/cloudera_deploy/defaults/basic_cluster.yml
+++ b/roles/cloudera_deploy/defaults/basic_cluster.yml
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cloudera_manager_version: 7.1.4
+cloudera_manager_version: 7.4.4
 
 clusters:
   - name: Basic Cluster
     services: [HDFS, YARN, ZOOKEEPER]
     repositories:
-      - https://archive.cloudera.com/cdh7/7.1.4.0/parcels/
+      - https://archive.cloudera.com/cdh7/7.1.7.0/parcels/
     configs:
       HDFS:
         DATANODE:

--- a/roles/cloudera_deploy/tasks/populate_download_mirror.yml
+++ b/roles/cloudera_deploy/tasks/populate_download_mirror.yml
@@ -81,7 +81,12 @@
     - name: Prepare host for s3 actions
       become: yes
       ansible.builtin.pip:
-        name: boto3 >= 1.4.4
+        name: "{{ __pip_item }}"
+      loop_control:
+        loop_var: __pip_item
+      loop:
+        - futures
+        - boto3 >= 1.4.4
 
     - name: Sync downloaded Files paths to S3 cache bucket
       become: yes


### PR DESCRIPTION
Hotfix for broken URL for CDH parcels repo. Also updated the `cloudera_manager_version` variable to the latest version.

We could use the value `latest` in the parcels repo URL but this doesn't seem possible for the CM version.  Also, we figured it's better to stick with known and tested versions as these are default values.  So I've went with hardcoded version numbers for both CDH and CM.

A note about commit https://github.com/cloudera-labs/cloudera-deploy/pull/55/commits/db7a5a7b62099b1e67c82d13bf001704fa36647c:
* When testing with a new set of parcels the Cloudera Deploy task to `Sync downloaded Files paths to S3 cache bucket` fails because of missing Python concurrent.futures module. 
* Doing a bit more digging, this task is running on the Utility VM created in AWS. These VMs are CentOS 7 images and use Python 2 which does not have the Futures module by default (see https://stackoverflow.com/a/32397747). 
* The fix I have put in https://github.com/cloudera-labs/cloudera-deploy/pull/55/commits/db7a5a7b62099b1e67c82d13bf001704fa36647c is to install the `futures` Python module along with boto3 in the `Prepare host for s3 actions` task of cloudera_deploy/tasks/populate_download_mirror.yml
