### PR TITLE
2021 07 freeipa dep fix

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -206,18 +206,6 @@
 # ENDBLOCK # Create Cluster Service Infrastructure
 # STARTBLOCK # Prepare TLS
 
-- name: Fetch CA certificates
-  hosts: ca_server
-  become: yes
-  gather_facts: no
-  tasks:
-    - ansible.builtin.include_role:
-        name: cloudera.cluster.infrastructure.ca_certs
-        tasks_from: fetch.yml
-  tags:
-    - fetch_ca
-    - full_cluster
-
 - name: Build TLS keystores and truststores
   hosts: tls
   become: yes


### PR DESCRIPTION
This change removes the ca_certs role from cluster.yml.

This functionality has been moved as part of the changes required to fix FreeIPA.

Note: This PR must be merged with the corresponding cloudera.cluster PR of the same name