### PR TITLE
quickstart.sh: Fix unintentional command execution.

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -78,8 +78,8 @@ if pgrep -x "ssh-agent" >/dev/null
 then
     echo "ssh-agent OK"
 else
-    echo "ssh-agent is stopped, please start it by running: eval `ssh-agent -s` "
-    #eval `ssh-agent -s` 
+    echo "ssh-agent is stopped, please start it by running: eval \`ssh-agent -s\` "
+    exit 1
 fi
 
 echo "Checking OS"


### PR DESCRIPTION
Two-line fix for `quickstart.sh`; see #74.