### PR TITLE
Support the use of other CDP control planes

### DIFF
--- a/roles/cloudera_deploy/tasks/init.yml
+++ b/roles/cloudera_deploy/tasks/init.yml
@@ -189,6 +189,7 @@
       cloudera_license_file: "{{ license_file | default(omit) }}"
       gcloud_credential_file: "{{ gcloud_credential_file | default(omit) }}"
       cdp_profile: "{{ cdp_profile | default(omit) }}"
+      cdp_region: "{{ cdp_region | default(omit) }}"
       aws_profile: "{{ aws_profile | default(omit) }}"
       force_teardown: "{{ purge | default(omit) }}"
       env_vars: "{{ env_vars | default(omit) }}"


### PR DESCRIPTION
Introduce a `cdp_region` variable that can be used to specify the CDP Control Plane region.

Changes done in conjunction with this cloudera.exe PR: https://github.com/cloudera-labs/cloudera.exe/pull/91