### PR TITLE
Convert terraform related global variables to a dictionary

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -41,8 +41,8 @@
     - name: Remove Terraform remote state resources if requested
       when:
         - globals.infra_deployment_engine == 'terraform'
-        - globals.terraform_auto_remote_state | bool
-        - globals.terraform_state_storage in ['remote_s3']
+        - globals.terraform.auto_remote_state | bool
+        - globals.terraform.state_storage in ['remote_s3']
       ansible.builtin.include_role:
         name: cloudera_deploy
         tasks_from: auto_terraform_state

--- a/readme.adoc
+++ b/readme.adoc
@@ -464,27 +464,28 @@ Terraform can optionally be used to create the cloud infrastructure. This will a
 | `ansible`
 | Needs to be set to `terraform` for Terraform-deployment.
 
-|`terraform_base_dir`
+4+| The parameters below are specified as keys in the `terraform` dictionary
+|`terraform.**base_dir**`
 | Top-level directory where all Terraform assets will be placed. Includes processed Jinja template files for Terraform,  timestamped artefact of Terraform files and the workspace directory where terraform apply/destroy is run.
 | `~/.config/cloudera-deploy/terraform`
 |
 
-|`terraform_state_storage`
+|`terraform.**state_storage**`
 |The type of backend storage to use for the Terraform state. 
 | `local`
 | Current options are `local` or `remote_s3`
 
-|`terraform_auto_remote_state`
+|`terraform.**auto_remote_state**`
 | Flag to allow Cloudera Deploy automatically provision remote state resources as part of its initialization. This will also teardown these resources during cleanup.
 | `False`
 |
 
-|`terraform_remote_state_bucket`
+|`terraform.**remote_state_bucket**`
 |The name of the Terraform state storage bucket. 
 | 
 | Required if using `remote_s3` state storage. Value is derived from `name_prefix` if terraform_auto_remote_state is True.
 
-|`terraform_remote_state_lock_table`
+|`terraform.**remote_state_lock_table**`
 |The name of the table to track locks of remote Terraform state.
 | 
 | Required if using `remote_s3` state storage. Value is derived from `name_prefix` if terraform_auto_remote_state is True.

--- a/roles/cloudera_deploy/tasks/auto_terraform_state.yml
+++ b/roles/cloudera_deploy/tasks/auto_terraform_state.yml
@@ -16,14 +16,14 @@
 
 - name: Resources for remote_s3 state storage
   when:
-    - globals.terraform_state_storage == 'remote_s3'
+    - globals.terraform.state_storage == 'remote_s3'
   block:
     
     # Create or Teardown the resources
     - name: AWS Bucket for Remote State Storage
       amazon.aws.aws_s3:
         region: "{{ globals.region }}"
-        bucket: "{{ globals.terraform_remote_state_bucket}}"
+        bucket: "{{ globals.terraform.remote_state_bucket}}"
         mode: "{{ ('teardown' not in ansible_run_tags)  | ternary('create', 'delete') }}" # Check ansible tag to determine action
         permission: private
       register: __infra_aws_storage_locations_info
@@ -31,7 +31,7 @@
     - name: AWS DynamoDB for Remote State Locking
       community.aws.dynamodb_table:
         region: "{{ globals.region }}"
-        name: "{{ globals.terraform_remote_state_lock_table }}"
+        name: "{{ globals.terraform.remote_state_lock_table }}"
         read_capacity: 1
         write_capacity: 1
         hash_key_name: LockID
@@ -43,6 +43,6 @@
       ansible.builtin.debug:
         msg:
           - "Resources for remote_s3 Terraform State created."
-          - "S3 Bucket Name: {{ globals.terraform_remote_state_bucket}}"
-          - "DynamoDB Locking Table: {{ globals.terraform_remote_state_lock_table}}"
+          - "S3 Bucket Name: {{ globals.terraform.remote_state_bucket}}"
+          - "DynamoDB Locking Table: {{ globals.terraform.remote_state_lock_table}}"
         verbosity: 3

--- a/roles/cloudera_deploy/tasks/init.yml
+++ b/roles/cloudera_deploy/tasks/init.yml
@@ -175,11 +175,12 @@
       region: "{{ infra_region | default(default_infra_region) }}"
       infra_deployment_engine: "{{ infra_deployment_engine | default(default_infra_deployment_engine) }}"
       infra_type: "{{ infra_type | default(default_infra_type) }}"
-      terraform_base_dir: "{{ terraform_base_dir | default(default_terraform_base_dir) | expanduser }}"
-      terraform_state_storage: "{{ terraform_state_storage | default(omit) }}"
-      terraform_auto_remote_state: "{{ terraform_auto_remote_state | default(False) }}"
-      terraform_remote_state_bucket: "{{ terraform_remote_state_bucket | default(omit) }}"
-      terraform_remote_state_lock_table: "{{ terraform_remote_state_lock_table | default(omit) }}"
+      terraform:
+        base_dir: "{{ terraform.base_dir | default(default_terraform_base_dir) | expanduser }}"
+        state_storage: "{{ terraform.state_storage | default(omit) }}"
+        auto_remote_state: "{{ terraform.auto_remote_state | default(False) }}"
+        remote_state_bucket: "{{ terraform.remote_state_bucket | default(omit) }}"
+        remote_state_lock_table: "{{ terraform.remote_state_lock_table | default(omit) }}"
       ssh:
         public_key_id: "{{ public_key_id | default(omit) }}"
         public_key_file: "{{ public_key_file | default(omit) }}"
@@ -235,8 +236,8 @@
     - globals.infra_deployment_engine == 'terraform'
   ansible.builtin.assert:
     that:
-      - globals.terraform_base_dir is defined
-      - globals.terraform_base_dir | length > 0
+      - globals.terraform.base_dir is defined
+      - globals.terraform.base_dir | length > 0
     fail_msg: "You must supply a 'terraform_base_dir' where Terraform assets will be placed"
     quiet: yes
 
@@ -245,8 +246,8 @@
     - globals.infra_deployment_engine == 'terraform'
   ansible.builtin.assert:
     that:
-      - (globals.terraform_auto_remote_state|bool is sameas true) or (globals.terraform_auto_remote_state|bool is sameas false)
-    fail_msg: "The terraform_auto_remote_state variable must be a boolean variable"
+      - (globals.terraform.auto_remote_state|bool is sameas true) or (globals.terraform.auto_remote_state|bool is sameas false)
+    fail_msg: "The terraform.auto_remote_state variable must be a boolean variable"
     quiet: yes
 
 # SSH
@@ -443,27 +444,29 @@
   when:
     - init__call_cloud_role | bool
     - globals.infra_deployment_engine == 'terraform'
-    - globals.terraform_auto_remote_state | bool
-    - globals.terraform_state_storage in ['remote_s3']
+    - globals.terraform.auto_remote_state | bool
+    - globals.terraform.state_storage in ['remote_s3']
   block:
     # Set resource variable names if not already done
     - name: Set variables for remote state bucket if not set
-      when: (globals.terraform_remote_state_bucket is not defined) or
-            ( (globals.terraform_remote_state_bucket) | length == 0)
+      when: (globals.terraform.remote_state_bucket is not defined) or
+            ( (globals.terraform.remote_state_bucket) | length == 0)
       ansible.builtin.set_fact:
         globals: "{{ globals | default({}) | combine(remote_state_vars, recursive=True) }}"
       vars:
         remote_state_vars:
-          terraform_remote_state_bucket: "{{ [globals.name_prefix, 'state-bucket'] | join('-') }}"
+          terraform:
+            remote_state_bucket: "{{ [globals.name_prefix, 'state-bucket'] | join('-') }}"
 
     - name: Set variables for remote state lock table if not set
-      when: (globals.terraform_remote_state_lock_table is not defined) or
-            (globals.terraform_remote_state_lock_table | length == 0)   
+      when: (globals.terraform.remote_state_lock_table is not defined) or
+            (globals.terraform.remote_state_lock_table | length == 0)   
       ansible.builtin.set_fact:
         globals: "{{ globals | default({}) | combine(remote_state_vars, recursive=True) }}"
       vars:
         remote_state_vars:
-          terraform_remote_state_lock_table: "{{ [globals.name_prefix, 'state-lock-table'] | join('-') }}"
+          terraform:
+            remote_state_lock_table: "{{ [globals.name_prefix, 'state-lock-table'] | join('-') }}"
 
     - name: Create remote state resources
       when: "'teardown' not in ansible_run_tags"


### PR DESCRIPTION
After reviewing the Terraform variables with @wmudge, we agreed that changing the Terraform global variables to be a dictionary gives a better structure to the inputs. Changes done in conjunction with [cloudera.exe PR#100](https://github.com/cloudera-labs/cloudera.exe/pull/100)

An example of the Terraform-related entries in the Cloudera-Deploy definition file following this change are shown below.

```yaml
# Deployment engine
infra_deployment_engine: terraform

# Terraform Options
terraform:
  state_storage: remote_s3
  auto_remote_state: True
  remote_state_bucket: example-state-bucket-config
  remote_state_lock_table: example-state-lock-table-config
```

Signed-off-by: Jim Enright <jenright@cloudera.com>