### PR TITLE
Fixes in pvc_base_prereqs_ext.yml

### DIFF
--- a/pvc_base_prereqs_ext.yml
+++ b/pvc_base_prereqs_ext.yml
@@ -63,7 +63,7 @@
 
 - name: Verify definition [verify_definition]
   hosts: cloudera_manager
-  gather_facts: no
+  gather_facts: yes
   roles:
     - cloudera.cluster.verify.definition
   tags:

--- a/pvc_base_prereqs_ext.yml
+++ b/pvc_base_prereqs_ext.yml
@@ -166,43 +166,6 @@
     - default_cluster
     - full_cluster
 
-# DB Connectors
-- name: Install MySQL Connector
-  hosts: cloudera_manager, cluster, ecs_nodes
-  gather_facts: no
-  become: yes
-  roles:
-    - role: cloudera.cluster.prereqs.mysql_connector
-      when: database_type == 'mysql' or database_type == 'mariadb'
-  tags:
-    - mysql_connector
-    - full_cluster
-
-- name: Install Oracle Connector
-  hosts: cloudera_manager, cluster, ecs_nodes
-  gather_facts: no
-  become: yes
-  roles:
-    - role: cloudera.cluster.prereqs.oracle_connector
-      when: database_type == 'oracle'
-  tags:
-    - oracle_connector
-    - full_cluster
-
-# ENDBLOCK # Prepare Nodes
-# STARTBLOCK # Install Cluster Service Infrastructure II
-
-- name: Install RDBMS
-  hosts: db_server
-  become: yes
-  roles:
-    - cloudera.cluster.infrastructure.rdbms
-  tags:
-    - database
-    - default_cluster
-    - full_cluster
-
-# ENDBLOCK # Install Cluster Service Infrastructure II
 # STARTBLOCK # Create Cluster Service Infrastructure
 
 - name: Install Kerberos Server
@@ -242,16 +205,6 @@
     - tls
     - full_cluster
 
-- name: Install HAProxy
-  hosts: haproxy
-  become: yes
-  roles:
-    - cloudera.cluster.infrastructure.haproxy
-  tags:
-    - ha
-    - full_cluster
-
-# ENDBLOCK # Create Cluster Service Infrastructure
 # STARTBLOCK # Prepare TLS
 
 - name: Build TLS keystores and truststores
@@ -298,5 +251,52 @@
         (tls | default(False)
         or manual_tls_cert_distribution | default(False))
         and not (autotls | default(False))
-
 # ENDBLOCK # NiFi TLS
+# DB Connectors
+- name: Install MySQL Connector
+  hosts: cloudera_manager, cluster, ecs_nodes
+  gather_facts: no
+  become: yes
+  roles:
+    - role: cloudera.cluster.prereqs.mysql_connector
+      when: database_type == 'mysql' or database_type == 'mariadb'
+  tags:
+    - mysql_connector
+    - full_cluster
+
+- name: Install Oracle Connector
+  hosts: cloudera_manager, cluster, ecs_nodes
+  gather_facts: no
+  become: yes
+  roles:
+    - role: cloudera.cluster.prereqs.oracle_connector
+      when: database_type == 'oracle'
+  tags:
+    - oracle_connector
+    - full_cluster
+
+# ENDBLOCK # Prepare Nodes
+# STARTBLOCK # Install Cluster Service Infrastructure II
+
+- name: Install RDBMS
+  hosts: db_server
+  become: yes
+  roles:
+    - cloudera.cluster.infrastructure.rdbms
+  tags:
+    - database
+    - default_cluster
+    - full_cluster
+
+# ENDBLOCK # Install Cluster Service Infrastructure II
+
+- name: Install HAProxy
+  hosts: haproxy
+  become: yes
+  roles:
+    - cloudera.cluster.infrastructure.haproxy
+  tags:
+    - ha
+    - full_cluster
+
+# ENDBLOCK # Create Cluster Service Infrastructure


### PR DESCRIPTION
1) Changed ordering of tasks in pvc_base_prereqs_ext.yml. For ECS, In order to leverage TLS enablement of the HMS's database, TLS cert create and signing must occur prior to dbms install/config. No code changed, just Task order

2) Play: Verify definition [verify_definition]. Need to gather facts here, when doing a static inventory as ref to ansible_os_family is made in cluster.repometa.main task.

Signed-off-by: Chuck Levesque <clevesque@cloudera.com|clevesque@cloudera.com>