### PR TITLE
Devel pvc update

### DIFF
--- a/pvc_base_postfix.yml
+++ b/pvc_base_postfix.yml
@@ -75,7 +75,7 @@
         - "'kts_passive' in groups"
   tags:
     - kts
-    - full_cluster
+#    - full_cluster
 
 - name: Handle KMS services
   hosts: localhost

--- a/pvc_base_prereqs_ext.yml
+++ b/pvc_base_prereqs_ext.yml
@@ -204,7 +204,7 @@
   gather_facts: yes
   become: yes
   roles:
-    - role: cloudera.cluster.infrastructure.krb5_client
+    - role: krb5_kdc_host is defined or 'krb5_server' in groups
   tags:
     - security
     - kerberos

--- a/pvc_base_prereqs_ext.yml
+++ b/pvc_base_prereqs_ext.yml
@@ -205,7 +205,6 @@
   become: yes
   roles:
     - role: cloudera.cluster.infrastructure.krb5_client
-      when: "'krb5_server' in groups"
   tags:
     - security
     - kerberos

--- a/pvc_base_prereqs_int.yml
+++ b/pvc_base_prereqs_int.yml
@@ -178,7 +178,7 @@
   become: yes
   roles:
     - role: cloudera.cluster.prereqs.kerberos
-      when: "'krb5_server' in groups"  # Only set up if cloudera.cluster has itself provisioned Kerberos
+      when: krb5_kdc_host is defined or 'krb5_server' in groups
   tags:
     - kerberos
     - prereqs


### PR DESCRIPTION
Allows client library configs for external kerberos and ldap, user is expected to provide krb5-* configs for the external AD or external MIT instance.
AD example:
krb5_realm: MYREALM.COM
krb5_kdc_admin_user: "admin-user@{{ krb5_realm }}"
krb5_kdc_admin_password: 
krb5_kdc_host: 
krb5_kdc_type: Active Directory
krb5_kdc_active_directory_prefix: "pvc-"
krb5_kdc_active_directory_suffix: "OU=some-ou,DC=company,DC=com"
krb5_enc_types: aes256-cts rc4-hmac
krb5_kdc_active_directory_set_encryption_types: true

MIT Example:
krb5_realm: MYREALM.COM
krb5_kdc_admin_user: "cloudera-scm/admin@{{ krb5_realm }}"
krb5_kdc_admin_password: "mypass"
krb5_kdc_type: MIT KDC
krb5_enc_types: "aes256-cts aes128-cts"


Signed-off-by: Chuck Levesque clevesque@cloudera.com